### PR TITLE
clean old profiles

### DIFF
--- a/site/profiles/manifests/software.pp
+++ b/site/profiles/manifests/software.pp
@@ -12,5 +12,6 @@ class profiles::software {
   include profiles::software::blueview
   include profiles::software::mathaddin
   include profiles::software::lanschool
+  include profiles::software::delprof2
 
 }

--- a/site/profiles/manifests/software/delprof2.pp
+++ b/site/profiles/manifests/software/delprof2.pp
@@ -1,0 +1,25 @@
+# == Class profiles::software::delprof2
+#
+#  This tool is called from a scheduled task
+#  to purge stale roaming profiles.
+class profiles::software::delprof2 {
+
+  file { 'delprof2exe':
+    path   => 'C:\itc\DelProf2.exe':
+    ensure => 'present',
+    source => '\\puppet-win.nmt.edu\winshare\packages\Delprof2_1.6.0\DelProf2.exe',
+  }
+
+  scheduled_task { 'Remove old profiles':
+    ensure    => 'present',
+    enabled   => true,
+    command   => 'C:\itc\DelProf2.exe',
+    arguments => '/q /d:1 /ed:admin* /ed:itc* /ed:act*',
+    trigger   => {
+      schedule   => 'daily',
+      start_time => '00:45',
+    }
+    require   => File['delprof2exe'],
+  }
+
+}

--- a/site/profiles/manifests/software/delprof2.pp
+++ b/site/profiles/manifests/software/delprof2.pp
@@ -5,7 +5,7 @@
 class profiles::software::delprof2 {
 
   file { 'delprof2exe':
-    path   => 'C:\itc\DelProf2.exe':
+    path   => 'C:\itc\DelProf2.exe',
     ensure => 'present',
     source => '\\puppet-win.nmt.edu\winshare\packages\Delprof2_1.6.0\DelProf2.exe',
   }

--- a/site/profiles/manifests/software/delprof2.pp
+++ b/site/profiles/manifests/software/delprof2.pp
@@ -19,7 +19,8 @@ class profiles::software::delprof2 {
       schedule   => 'daily',
       start_time => '00:45',
     }
-    require   => File['delprof2exe'],
   }
+
+  File['delprof2exe'] -> Scheduled_task['Remove old profiles']
 
 }

--- a/site/profiles/manifests/software/delprof2.pp
+++ b/site/profiles/manifests/software/delprof2.pp
@@ -5,7 +5,7 @@
 class profiles::software::delprof2 {
 
   file { 'delprof2exe':
-    path   => 'C:\itc\DelProf2.exe',
+    path   => 'C:\itc\bin\DelProf2.exe',
     ensure => 'present',
     source => '\\puppet-win.nmt.edu\winshare\packages\Delprof2_1.6.0\DelProf2.exe',
   }
@@ -13,7 +13,7 @@ class profiles::software::delprof2 {
   scheduled_task { 'Remove old profiles':
     ensure    => 'present',
     enabled   => true,
-    command   => 'C:\itc\DelProf2.exe',
+    command   => 'C:\itc\bin\DelProf2.exe',
     arguments => '/q /d:1 /ed:admin* /ed:itc* /ed:act*',
     trigger   => {
       schedule   => 'daily',


### PR DESCRIPTION
Use https://helgeklein.com/free-tools/delprof2-user-profile-deletion-tool/ to remove stale roaming profiles, since Windows can't seem to do it, as per FTE.